### PR TITLE
Fix short card text alignment

### DIFF
--- a/app/_components/Item/UnreadItem.tsx
+++ b/app/_components/Item/UnreadItem.tsx
@@ -62,6 +62,7 @@ const actionAreaSx: SxProps = {
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'flex-start',
+  alignItems: 'stretch'
 };
 const imageSx: SxProps<Theme> = {
   height: 'auto',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,10 +13,12 @@ import GamesCzItems from "./_components/GamesCzItems";
 const rootSx: SxProps = {
   height: '100vh',
 };
-
 const mainSx: SxProps = {
   py: 2,
   overflowX: "hidden",
+};
+const logoSx: SxProps = {
+  textDecoration: 'none',
 };
 
 export default function Page() {
@@ -24,9 +26,11 @@ export default function Page() {
     <Box sx={rootSx}>
       <AppBar position="fixed" color="default">
         <Toolbar variant="dense">
-          <Typography variant="h6" color="primary" component="div">
-            Games.cz News
-          </Typography>
+          <Box component="a" sx={logoSx} href="https://games.tiscali.cz/">
+            <Typography variant="h6" color="primary" component="div">
+              Games.cz News
+            </Typography>
+          </Box>
         </Toolbar>
       </AppBar>
       <Toolbar />


### PR DESCRIPTION
If the text is short it's aligned to the center rather then to the left side of the card. It breaks the visual flow.

+ The PR adds a link to the Games.cz from the main logo.